### PR TITLE
Adding hint on IPv6 zones

### DIFF
--- a/docs/features/as112.md
+++ b/docs/features/as112.md
@@ -17,7 +17,7 @@ AS112 services are provided around the world by a group of volunteers and, very 
 
 ## Building an AS112 Service
 
-You can find instructions for building an AS112 service in [rfc7534](https://tools.ietf.org/html/rfc7534). You should also add AS112 redirection using DNAME functionality as per [rfc7535](https://tools.ietf.org/html/rfc7535).
+You can find instructions for building an AS112 service in [rfc7534](https://tools.ietf.org/html/rfc7534). You should also add AS112 redirection using DNAME functionality as per [rfc7535](https://tools.ietf.org/html/rfc7535). If you are also running IPv6 make sure to implement the [IPv6 Zones](https://www.as112.net/ipv6-trials.html) as well.
 
 You will also find a lot more information and how-tos on the official website at: [https://www.as112.net/](https://www.as112.net/).
 


### PR DESCRIPTION
It might also be worth expanding the prefixes in the introduction by:
```
0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa (Unspecified)
                            f.f.ip6.arpa (Multicast)
                          8.e.f.ip6.arpa (Link-Local Scope)
                          9.e.f.ip6.arpa (Link-Local Scope)
                          a.e.f.ip6.arpa (Link-Local Scope)
                          b.e.f.ip6.arpa (Link-Local Scope)
                          c.e.f.ip6.arpa (Link-Local Scope)
                          d.e.f.ip6.arpa (Link-Local Scope)
                          e.e.f.ip6.arpa (Link-Local Scope)
                          f.e.f.ip6.arpa (Link-Local Scope)
                        0.0.c.f.ip6.arpa (Unique Locally Assigned)
                        0.0.d.f.ip6.arpa (Unique Locally Assigned)
                0.0.0.0.1.0.0.2.ip6.arpa (Teredo)
```
