### PR TITLE
Running update-l2database.pl without --vlanid is deprecated

### DIFF
--- a/docs/features/layer2-addresses.md
+++ b/docs/features/layer2-addresses.md
@@ -107,7 +107,8 @@ joe /usr/local/etc/ixpmanager.conf #and set database settings
 cp $IXPROOT/tools/runtime/l2database/update-l2database.pl /usr/local/bin
 
 # and then add it to your periodic cron job with:
-/usr/local/bin/update-l2database.pl
+# replace X with the id of your vlan from the database:
+/usr/local/bin/update-l2database.pl --vlanid=X
 ```
 
 ## OUI Database


### PR DESCRIPTION
Running update-l2database.pl without --vlanid is deprecated, says the code itself:

```
print STDERR "WARNING: executing this program without the \"--vlanid\" parameter is deprecated and will be removed in a future version of IXP Manager.\n";
```